### PR TITLE
Bump ENHSP version to 0.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import shutil
 ENHSP_dst = './up_enhsp/ENHSP'
 ENHSP_PUBLIC = 'ENHSP-Public'
 COMPILE_CMD = './compile'
-ENHSP_TAG = 'enhsp20-0.9.7'
+ENHSP_TAG = 'enhsp20-0.10.0'
 ENHSP_REPO = 'https://gitlab.com/enricos83/ENHSP-Public'
 JDK_REQUIRE = 17
 


### PR DESCRIPTION
Hi, I've noticed that the ENHSP version used here is slightly outdated. It in particular contains a bug when using helpful transitions with the parameter `-ht true`. This PR bumps the ENHSP version to fix the bug.