### PR TITLE
Replace pkg_resources resource lookups

### DIFF
--- a/test/test_up_enhsp.py
+++ b/test/test_up_enhsp.py
@@ -1,8 +1,12 @@
+from pathlib import Path
+
 import unified_planning
 from unified_planning.shortcuts import *
 from unified_planning.io.pddl_reader import PDDLReader
 from unittest import TestCase
-import pkg_resources
+
+
+PDDL_DIR = Path(__file__).parent / 'PDDL'
 
 
 class ENHSPtest(TestCase):
@@ -40,7 +44,10 @@ class ENHSPtest(TestCase):
 
     def test_enhsp_from_pddl(self):
         reader = PDDLReader()
-        pddl_problem = reader.parse_problem(pkg_resources.resource_filename(__name__, 'PDDL/NumRover.pddl'), pkg_resources.resource_filename(__name__, 'PDDL/pfile1'))
+        pddl_problem = reader.parse_problem(
+            str(PDDL_DIR / 'NumRover.pddl'),
+            str(PDDL_DIR / 'pfile1'),
+        )
 
         with OneshotPlanner(name='enhsp') as planner:
             plan = planner.solve(pddl_problem)

--- a/up_enhsp/enhsp_planner.py
+++ b/up_enhsp/enhsp_planner.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib.resources import files
 import unified_planning as up
 from unified_planning.engines import PlanGenerationResult, PlanGenerationResultStatus
 from unified_planning.model import ProblemKind
@@ -13,6 +13,8 @@ credits = Credits('ENHSP',
                   'GPL',
                   'Expressive Numeric Heuristic Search Planner.',
                   'ENHSP is a planner supporting (sub)optimal classical and numeric planning with linear and non-linear expressions.')
+
+ENHSP_JAR = str(files(__package__).joinpath('ENHSP').joinpath('enhsp.jar'))
 
 
 class ENHSPEngine(PDDLPlanner):
@@ -33,7 +35,7 @@ class ENHSPEngine(PDDLPlanner):
         return command
 
     def _get_cmd(self, domain_filename: str, problem_filename: str, plan_filename: str) -> List[str]:
-        base_command = ['java', '-jar', pkg_resources.resource_filename(__name__, 'ENHSP/enhsp.jar'), '-o', domain_filename, '-f', problem_filename, '-sp', plan_filename,'-npm']
+        base_command = ['java', '-jar', ENHSP_JAR, '-o', domain_filename, '-f', problem_filename, '-sp', plan_filename,'-npm']
         return self._manage_parameters(base_command)
 
     def _result_status(
@@ -107,7 +109,7 @@ class ENHSPAnytimeEngine(ENHSPEngine, PDDLAnytimePlanner):
 
 
     def _get_anytime_cmd(self, domain_filename: str, problem_filename: str, plan_filename: str) -> List[str]:
-        command = ['java', '-jar', pkg_resources.resource_filename(__name__, 'ENHSP/enhsp.jar'),
+        command = ['java', '-jar', ENHSP_JAR,
                    '-o', domain_filename, '-f', problem_filename, '-sp', plan_filename,'-anytime', '-npm']
         return self._manage_parameters(command)
 
@@ -139,7 +141,7 @@ class ENHSPOptEngine(ENHSPEngine):
         return 'OPT-enhsp'
 
     def _get_cmd(self, domain_filename: str, problem_filename: str, plan_filename: str) -> List[str]:
-        command = ['java', '-jar', pkg_resources.resource_filename(__name__, 'ENHSP/enhsp.jar'),
+        command = ['java', '-jar', ENHSP_JAR,
                    '-o', domain_filename, '-f', problem_filename, '-sp', plan_filename,
                    '-s','WAStar','-h','hrmax', '-npm']
         return command
@@ -183,7 +185,7 @@ class ENHSPOptBlindEngine(ENHSPOptEngine):
         return 'BLIND-enhsp'
 
     def _get_cmd(self, domain_filename: str, problem_filename: str, plan_filename: str) -> List[str]:
-        command = ['java', '-jar', pkg_resources.resource_filename(__name__, 'ENHSP/enhsp.jar'),
+        command = ['java', '-jar', ENHSP_JAR,
                    '-o', domain_filename, '-f', problem_filename, '-sp', plan_filename,
                    '-s','WAStar','-h','blind','-ties','larger_g', '-npm']
         return command


### PR DESCRIPTION
## Summary
- replace `pkg_resources.resource_filename()` in the ENHSP command builders with `importlib.resources.files()`
- resolve PDDL test fixtures from `Path(__file__).parent` instead of `pkg_resources`

Fixes #23.

## Validation
- `git diff --check HEAD~1..HEAD`
- Not run locally (tests)