### PR TITLE
Declare unified-planning compatibility floor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,9 @@ setup(name='up_enhsp',
       package_data={
           "": ["ENHSP/enhsp.jar","ENHSP/libs/*"],
       },
+      install_requires=[
+          'unified-planning>=1.3.0',
+      ],
       cmdclass={
           'build_py': InstallENHSP,
           'develop': InstallENHSPdevelop,


### PR DESCRIPTION
Summary:
- declare `unified-planning>=1.3.0` in `setup.py`
- align package metadata with the `ProblemKind(version=3)` features used by the planner integration

Validation:
- `git diff --check HEAD~1..HEAD`
- static search for the current ProblemKind v3 features and the new dependency floor
- Tests not run locally

Fixes #20